### PR TITLE
🐛 [Fix] 이력서 pdf 생성 시 문제 해결 #40

### DIFF
--- a/src/app/(home)/myResume/[resumeId]/_components/PdfDownloadButton.tsx
+++ b/src/app/(home)/myResume/[resumeId]/_components/PdfDownloadButton.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { saveAs } from "file-saver";
+import { pdf } from "@react-pdf/renderer";
+import { Button } from "@/components/ui/button";
+import ResumeDocument from "./ResumeDocument";
+import { ResumeDetailResponse } from "../../../community/_hooks/useResumeQuery";
+import { FileText } from "lucide-react";
+
+type Props = {
+  resume: ResumeDetailResponse;
+};
+
+const PdfDownloadButton = ({ resume }: Props) => {
+  const downloadPdf = async () => {
+    const fileName = `${resume.result.memberName}_이력서_깃트폴리오`;
+    const blob = await pdf(<ResumeDocument resume={resume} />).toBlob();
+    saveAs(blob, fileName);
+  };
+
+  return (
+    <Button className="flex gap-2 bg-red-500 pr-6" onClick={downloadPdf}>
+      <FileText />
+      <div>pdf로 저장</div>
+    </Button>
+  );
+};
+
+export default PdfDownloadButton;

--- a/src/app/(home)/myResume/[resumeId]/_components/ResumeDocument.tsx
+++ b/src/app/(home)/myResume/[resumeId]/_components/ResumeDocument.tsx
@@ -1,0 +1,273 @@
+import React from "react";
+import {
+  Document,
+  Page,
+  Text,
+  Image as PImage,
+  View,
+  StyleSheet,
+  Font,
+  Link,
+  Svg,
+} from "@react-pdf/renderer";
+import { createTw } from "react-pdf-tailwind";
+import { ResumeDetailResponse } from "../../../community/_hooks/useResumeQuery";
+import {
+  PositionType,
+  positionTypeMap,
+  WorkType,
+  workTypeMap,
+} from "@/app/types/type";
+
+type FontWeight = "normal" | "bold" | "light" | undefined;
+
+Font.register({
+  family: "Pretendard",
+  fonts: [
+    {
+      src: "../fonts/Pretendard-Regular.ttf",
+      fontWeight: "300" as FontWeight,
+    },
+    {
+      src: "../fonts/Pretendard-SemiBold.ttf",
+      fontWeight: "600" as FontWeight,
+    },
+    {
+      src: "../fonts/Pretendard-Bold.ttf",
+      fontWeight: "700" as FontWeight,
+    },
+  ],
+});
+
+const tw = createTw({
+  theme: {
+    fontFamily: {
+      pretendard: ["Pretendard"],
+    },
+  },
+});
+
+type Props = {
+  resume: ResumeDetailResponse;
+};
+
+function getIconForLink(url: string) {
+  if (url.includes("github.com")) {
+    return "http://localhost:3000/images/github-mark.png";
+  } else if (url.includes("linkedin.com")) {
+    return "http://localhost:3000/images/linkedin.png";
+  } else if (url.includes("notion.site")) {
+    return "http://localhost:3000/images/notion.png";
+  } else if (url.includes("tistory.com")) {
+    return "http://localhost:3000/images/tistory.png";
+  } else {
+    return "http://localhost:3000/images/default-link.png";
+  }
+}
+
+const ResumeDocument2 = ({ resume }: Props) => {
+  return (
+    <Document>
+      <Page size="A4" style={tw("p-8 px-32 font-pretendard")}>
+        {/* 헤더 */}
+        <View style={tw("flex flex-row mb-2")}>
+          <View style={tw("flex-1")}>
+            <Text style={tw("text-3xl font-bold")}>
+              {resume.result.memberName}
+            </Text>
+            <Text style={tw("text-lg")}>
+              {positionTypeMap[resume.result.position as PositionType]} 개발자
+            </Text>
+          </View>
+          <PImage
+            style={tw("w-52 h-52 rounded-lg")}
+            src={resume.result.avatarUrl}
+          />
+        </View>
+
+        {/* 자기소개 */}
+        <View style={tw("border-b border-black my-4")} />
+        <View style={tw("mb-6")}>
+          <Text style={tw("text-xl font-bold mb-2")}>자기소개</Text>
+          <Text style={tw("text-xs leading-relaxed")}>
+            {resume.result.aboutMe}
+          </Text>
+        </View>
+
+        {/* 경력 */}
+        {resume.result.workExperiences.length > 0 && (
+          <>
+            <View style={tw("border-b border-black my-4")} />
+            <View>
+              <Text style={tw("text-xl font-bold mb-2")}>경력</Text>
+              {resume.result.workExperiences.map((experience, index) => (
+                <View key={index} style={tw("mb-4")}>
+                  <Text style={tw("text-lg font-semibold")}>
+                    {experience.companyName}
+                  </Text>
+                  <Text style={tw("text-xs text-gray-400 mb-1")}>
+                    {experience.departmentName} | {experience.role} |{" "}
+                    {workTypeMap[experience.workType as WorkType]}
+                  </Text>
+                  <Text style={tw("text-xs text-gray-400")}>
+                    {experience.startedAt} ~ {experience.endedAt}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+
+        {/* 프로젝트 */}
+        {resume.result.projects.length > 0 && (
+          <>
+            <View style={tw("border-b border-black my-4")} />
+            <View style={tw("mb-6")}>
+              <Text style={tw("text-xl font-bold mb-2")}>프로젝트</Text>
+              {resume.result.projects.map((project, index) => (
+                <View key={index} style={tw("mb-4")}>
+                  <Text style={tw("text-base font-semibold mb-2")}>
+                    {project.projectName}
+                  </Text>
+                  <Link
+                    src={project.repoLink}
+                    style={tw("text-xs text-gray-400 mb-2")}
+                  >
+                    {project.repoLink}
+                  </Link>
+                  <Text style={tw("text-xs text-gray-400 mb-2")}>
+                    {project.projectStartedAt} ~ {project.projectEndedAt}
+                  </Text>
+                  <Text style={tw("text-xs text-gray-400 mb-4")}>
+                    기술 스택: {project.skillSet}
+                  </Text>
+                  <Text style={tw("text-sm")}>
+                    {project.projectDescription}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+
+        {/* 교육 */}
+        {resume.result.educations.length > 0 && (
+          <>
+            <View style={tw("border-b border-black my-4")} />
+            <View style={tw("mb-6")}>
+              <Text style={tw("text-xl font-bold mb-2")}>교육</Text>
+              {resume.result.educations.map((education, index) => (
+                <View key={index} style={tw("mb-4")}>
+                  <Text style={tw("text-lg font-semibold")}>
+                    {education.schoolName}
+                  </Text>
+                  <Text style={tw("text-xs text-gray-400 mb-1")}>
+                    {education.schoolType} | {education.major}
+                  </Text>
+                  <Text style={tw("text-xs text-gray-400")}>
+                    {education.startedAt} ~ {education.endedAt} |{" "}
+                    {education.graduationStatus}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+
+        {/* 자격증 */}
+        {resume.result.certificates.length > 0 && (
+          <>
+            <View style={tw("border-b border-black my-4")} />
+            <View style={tw("mb-6")}>
+              <Text style={tw("text-xl font-bold mb-2")}>자격증</Text>
+              {resume.result.certificates.map((certificate, index) => (
+                <View key={index} style={tw("mb-4")}>
+                  <Text style={tw("text-lg font-semibold")}>
+                    {certificate.certificateName}
+                  </Text>
+                  <Text style={tw("text-xs text-gray-400")}>
+                    {certificate.certificateGrade} |{" "}
+                    {certificate.certificateOrganization}
+                  </Text>
+                  <Text style={tw("text-xs text-gray-400")}>
+                    {certificate.certificatedAt}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+
+        {/* 기술스택 */}
+        {resume.result.techStack.length > 0 && (
+          <>
+            <View style={tw("border-b border-black my-4")} />
+            <View style={tw("mb-6")}>
+              <Text style={tw("text-xl font-bold mb-2")}>기술스택</Text>
+              <View style={tw("flex flex-row flex-wrap")}>
+                {resume.result.techStack.map((tech, index) => (
+                  <Text
+                    key={index}
+                    style={tw(
+                      "text-sm mr-2 p-1 px-2 border bg-gray-50 border-gray-600 rounded-lg",
+                    )}
+                  >
+                    {tech}
+                  </Text>
+                ))}
+              </View>
+            </View>
+          </>
+        )}
+
+        {/* 개인 링크 */}
+        {resume.result.links.length > 0 && (
+          <>
+            {/* 구분선 */}
+            <View style={tw("border-b border-black my-4")} />
+
+            <View>
+              <Text style={tw("text-2xl font-semibold")}>개인 링크</Text>
+              {resume.result.links.map((link, index) => (
+                <View
+                  key={index}
+                  style={tw(
+                    "flex flex-row items-center w-full p-2 border border-gray-400 rounded-md bg-gray-50 mb-2",
+                  )}
+                >
+                  {/* 아이콘 영역 */}
+                  <View
+                    style={tw(
+                      "flex items-center justify-center p-4 border-r border-gray-200 w-14 h-14",
+                    )}
+                  >
+                    <PImage
+                      // src={"../images/github-mark.png"}
+                      src={getIconForLink(link.linkUrl)}
+                      style={tw("w-full h-full")}
+                    />
+                  </View>
+                  {/* 링크 정보 */}
+                  <View style={tw("flex flex-col flex-1 ml-2")}>
+                    <Text
+                      style={tw("text-xs font-semibold text-gray-600 mb-2")}
+                    >
+                      {link.linkUrl}
+                    </Text>
+                    <Link src={link.linkUrl}>
+                      <Text style={tw("text-black font-semibold text-xs")}>
+                        {link.linkTitle}
+                      </Text>
+                    </Link>
+                  </View>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+      </Page>
+    </Document>
+  );
+};
+
+export default ResumeDocument2;

--- a/src/app/(home)/onboarding/page.tsx
+++ b/src/app/(home)/onboarding/page.tsx
@@ -104,7 +104,7 @@ export default function Page() {
   });
 
   const [iconTypes, setIconTypes] = useState(
-    Array(linksFields.length).fill(<Link />)
+    Array(linksFields.length).fill(<Link />),
   );
 
   useRepositoryQuery();
@@ -130,13 +130,13 @@ export default function Page() {
       "memberUpdateRequestDTO",
       new Blob([JSON.stringify(memberUpdateRequestDTO)], {
         type: "application/json",
-      })
+      }),
     );
     formData.append(
       "memberAdditionalRequestDTO",
       new Blob([JSON.stringify(memberAdditionalRequestDTO)], {
         type: "application/json",
-      })
+      }),
     );
     formData.append("imageFile", imageFile as Blob);
 
@@ -190,6 +190,13 @@ export default function Page() {
 
   return (
     <div className="max-w-3xl p-4 mx-auto space-y-6">
+      <div className="text-center text-2xl font-bold">
+        기본 정보(필수) / 추가 정보(선택) 입력
+      </div>
+      <div className="text-center">
+        많은 정보를 입력해주시면 더 좋은 이력서가 만들어집니다!
+      </div>
+      <Separator />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
           {/* 기본정보 */}
@@ -298,7 +305,7 @@ export default function Page() {
                                   <SelectItem key={key} value={key}>
                                     {label}
                                   </SelectItem>
-                                )
+                                ),
                               )}
                             </SelectContent>
                           </Select>

--- a/src/app/(home)/onboarding/repositories/_hooks/useResumeMutation.tsx
+++ b/src/app/(home)/onboarding/repositories/_hooks/useResumeMutation.tsx
@@ -12,6 +12,8 @@ type OnboardingRequest = {
 
 export function useResumeMutation() {
   const router = useRouter();
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationKey: ["createResume"],
     mutationFn: async ({ accessToken, data }: OnboardingRequest) => {
@@ -54,7 +56,7 @@ export function useResumeMutation() {
         ),
         // error: (error) => error.message || "이력서 등록에 실패했습니다.",
         error: (error) => {
-          router.push("/onboarding/repositories");
+          // router.push("/onboarding/repositories");
           return error.message || "이력서 등록에 실패했습니다.";
         },
         position: "top-right",
@@ -62,6 +64,7 @@ export function useResumeMutation() {
       });
     },
     onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["resume"] });
       // toast.custom((t) => (
       //   <div></div>
       // ));

--- a/src/app/(home)/onboarding/repositories/page.tsx
+++ b/src/app/(home)/onboarding/repositories/page.tsx
@@ -2,7 +2,7 @@ import Repository from "./_components/repository";
 
 export default function Page() {
   return (
-    <div className="flex flex-col items-center justify-center w-full h-full ">
+    <div className="flex flex-col items-center justify-center w-full h-[500px]">
       <Repository />
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #40 

## 📝작업 내용
- 이력서 pdf 저장 로직 변경
- 기존 react-to-pdf 라이브러리에서 react-pdf 라이브러리로 변경
  - 이미지 캡쳐 방식으로 만들던 기존과는 다르게 직접 컴포넌트를 하나씩 구현하여 pdf를 생성하는 방식
  - 이미지 깨짐 현상 해결, 페이지 상/하단 여백 및 구분, 폰트 적용(Pretendard)
- 기존 이력서 생성 실패 시 다시 온보딩 페이지로 이동 로직 대신 일단 /community로 넘어가도록 하여 다시 이력서 생성 화면으로 유도시키는 방식으로 수정

### 스크린샷 (선택)
<img width="1116" alt="스크린샷 2024-11-07 오전 11 34 26" src="https://github.com/user-attachments/assets/ad7a7da7-66d1-409d-aa5b-06fdf9d45465">
<img width="479" alt="image" src="https://github.com/user-attachments/assets/71e38a0b-c43f-4e96-9abe-6b229c7945c5">


## 💬리뷰 요구사항(선택)

