### PR TITLE
🚑  hotfix: 이미지 url 임시 변경

### DIFF
--- a/src/app/(home)/_hooks/useNotificationQuery.ts
+++ b/src/app/(home)/_hooks/useNotificationQuery.ts
@@ -40,5 +40,6 @@ export const useNotificationsQuery = () => {
     queryKey: ["notifications"],
     queryFn: () => getNotifications(accessToken!),
     refetchInterval: 60000, // 1분마다 polling
+    retry: 0,
   });
 };

--- a/src/app/(home)/community/_components/community.tsx
+++ b/src/app/(home)/community/_components/community.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/tooltip";
 import { debounce } from "lodash";
 import { useNotificationsQuery } from "../../_hooks/useNotificationQuery";
+import Markdown from "react-markdown";
 
 export default function Community() {
   const searchParams = useSearchParams();
@@ -265,7 +266,10 @@ export default function Community() {
                   </div>
                 </div>
                 <Image
-                  src={resume.avatarUrl}
+                  src={resume.avatarUrl.replace(
+                    "https://gitfolio.s3.amazonaws.com/https://",
+                    "https://",
+                  )}
                   alt="프로필 이미지"
                   width={300}
                   height={300}
@@ -300,7 +304,8 @@ export default function Community() {
                     </button>
                   </div>
                   <p className="mt-2 text-sm text-gray-600 whitespace-pre-line line-clamp-6">
-                    {resume.aboutMe}
+                    {/* {resume.aboutMe} */}
+                    {resume.aboutMe.replace(/\*/g, "")}
                   </p>
                 </div>
               </Link>

--- a/src/app/(home)/myResume/[resumeId]/page.tsx
+++ b/src/app/(home)/myResume/[resumeId]/page.tsx
@@ -214,7 +214,10 @@ export default function Page({ params }: Props) {
             </div>
             <div className="relative w-[228px] h-[228px]">
               <Image
-                src={resume.result.avatarUrl}
+                src={resume.result.avatarUrl.replace(
+                  "https://gitfolio.s3.amazonaws.com/https://",
+                  "https://",
+                )}
                 alt="프로필 이미지"
                 priority
                 fill


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
- 이미지 url을 임시 변경함(백엔드에서 보낼 때 주소가 두 번 겹쳐서 옴)
- notification 쿼리 retry 0으로 설정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
