### PR TITLE
[Fix] 댓글에 한글이 있으면 기능이 제대로 동작하지 않는 문제 & 이력서 화면 API 에러 시 프로세스 추가

### DIFF
--- a/src/app/(home)/community/_hooks/useResumeQuery.ts
+++ b/src/app/(home)/community/_hooks/useResumeQuery.ts
@@ -161,6 +161,7 @@ export const useResumeDetailQuery = (resumeId: string) => {
   return useQuery<ResumeDetailResponse>({
     queryKey: ["resumes", resumeId],
     queryFn: () => getOneResume(resumeId),
+    retry: 0,
   });
 };
 

--- a/src/app/(home)/community/resumes/[resumeId]/_components/resume-comment.tsx
+++ b/src/app/(home)/community/resumes/[resumeId]/_components/resume-comment.tsx
@@ -12,6 +12,7 @@ import CommentDeleteModal from "./comment-delete-modal";
 import { Button } from "@/components/ui/button";
 import { useProfileQuery } from "@/app/(home)/onboarding/_hooks/useProfileQuery";
 import ResumeCommentSkeleton from "./ResumeCommentSkeleton";
+import { LoadingButton } from "@/components/ui/loading-button";
 
 type Props = {
   resumeId: string;
@@ -21,7 +22,7 @@ export default function ResumeComment({ resumeId }: Props) {
   const [comment, setComment] = useState<string>("");
 
   const { data: comments, isLoading } = useResumeCommentQuery(resumeId);
-  const { mutate } = useResumeCommentCreate(resumeId);
+  const { mutate, isPending } = useResumeCommentCreate(resumeId);
   const { mutate: deleteComment } = useResumeCommentDelete(resumeId);
   const { data: userProfile } = useProfileQuery();
 
@@ -92,18 +93,20 @@ export default function ResumeComment({ resumeId }: Props) {
             value={comment}
             onChange={(e) => setComment(e.target.value)}
             placeholder="댓글을 남겨주세요!"
-            onKeyDown={(e) => {
+            onKeyDown={(e: any) => {
+              if (e.isComposing || e.keyCode === 229) return;
               if (e.key === "Enter") {
                 onSubmit();
               }
             }}
           />
-          <Button
+          <LoadingButton
+            loading={isPending}
             onClick={() => onSubmit()}
             className="p-2 px-4 text-white bg-blue-500 rounded-full cursor-pointer hover:bg-blue-400"
           >
             저장
-          </Button>
+          </LoadingButton>
         </div>
       </div>
     </div>

--- a/src/app/(home)/community/resumes/[resumeId]/page.tsx
+++ b/src/app/(home)/community/resumes/[resumeId]/page.tsx
@@ -23,6 +23,8 @@ import ResumeSkeleton from "./_components/resume-skeleton";
 import Markdown from "react-markdown";
 import { useCallback, useEffect, useState } from "react";
 import { generateTabItems } from "./_lib/util";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
 
 type Props = {
   params: { resumeId: string };
@@ -30,9 +32,11 @@ type Props = {
 
 export default function Page({ params }: Props) {
   const resumeId = params.resumeId;
-  const [activeTab, setActiveTab] = useState<string>("selfIntroduction");
+  const [activeTab, setActiveTab] = useState<string>("aboutMe");
 
-  const { data: resume } = useResumeDetailQuery(resumeId);
+  const router = useRouter();
+
+  const { data: resume, error } = useResumeDetailQuery(resumeId);
 
   const handleIconChange = (url: string) => {
     if (url.includes("github.com")) {
@@ -95,6 +99,13 @@ export default function Page({ params }: Props) {
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, [handleScroll]);
+
+  useEffect(() => {
+    if (error && (error as any).status === 403) {
+      toast.error("접근 권한이 없습니다."); // Display error message
+      router.push("/community"); // Redirect to /community
+    }
+  }, [error, router]);
 
   if (!resume) {
     return <ResumeSkeleton />;
@@ -169,7 +180,7 @@ export default function Page({ params }: Props) {
 
               {/* 자기소개 */}
               <Separator className="bg-black" />
-              <div id="selfIntroduction" className="space-y-4">
+              <div id="aboutMe" className="space-y-4">
                 <div className="text-2xl font-semibold">자기소개</div>
                 {/* <div className="whitespace-pre-line">{resume.result.aboutMe}</div> */}
                 <Markdown className="prose break-words prose-p:leading-relaxed prose-pre:p-0">

--- a/src/app/(home)/onboarding/_hooks/useOnboardingUpdate.ts
+++ b/src/app/(home)/onboarding/_hooks/useOnboardingUpdate.ts
@@ -14,7 +14,7 @@ export function useOnboardingUpdate() {
 
   return useMutation({
     mutationKey: ["onboardingUpdate"],
-    mutationFn: async ({ accessToken, data }: OnboardingRequest) => {
+    mutationFn: async ({ data }: OnboardingRequest) => {
       const response = await customFetch(`/api/members/me`, {
         method: "PUT",
         credentials: "include",

--- a/src/app/(home)/onboarding/repositories/_hooks/useResumeMutation.tsx
+++ b/src/app/(home)/onboarding/repositories/_hooks/useResumeMutation.tsx
@@ -45,7 +45,7 @@ export function useResumeMutation() {
       return toast.promise(promise, {
         loading: "이력서 생성 중...",
         success: (success: any) => {
-          queryClient.invalidateQueries({ queryKey: ["resume"] });
+          queryClient.invalidateQueries({ queryKey: ["resumes"] });
           return (
             <div className="flex items-center justify-between w-full">
               <div className="font-bold">이력서 등록에 성공하였습니다.</div>

--- a/src/app/(myResume)/myResume/[resumeId]/page.tsx
+++ b/src/app/(myResume)/myResume/[resumeId]/page.tsx
@@ -26,6 +26,8 @@ import { useVisibility } from "./hooks/useVisibility";
 import { useMyResumeDetailQuery } from "@/app/(home)/community/_hooks/useResumeQuery";
 import ResumeComment from "@/app/(home)/community/resumes/[resumeId]/_components/resume-comment";
 import MyResumeDetailSkeleton from "./_components/MyResumeDetailSkeleton";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 type Props = {
   params: { resumeId: string };
@@ -34,7 +36,9 @@ type Props = {
 export default function Page({ params }: Props) {
   const resumeId = params.resumeId;
 
-  const { data: resume } = useMyResumeDetailQuery(resumeId);
+  const router = useRouter();
+
+  const { data: resume, error } = useMyResumeDetailQuery(resumeId);
 
   const [messages, setMessages] = useState<string[]>([]);
   const [input, setInput] = useState("");
@@ -102,6 +106,13 @@ export default function Page({ params }: Props) {
       document.removeEventListener("mouseup", onMouseUp);
     };
   }, [onMouseUp]);
+
+  useEffect(() => {
+    if (error && (error as any).status === 403) {
+      toast.error("접근 권한이 없습니다."); // Display error message
+      router.push("/community"); // Redirect to /community
+    }
+  }, [error, router]);
 
   const handlePopover = () => {
     setIsPopOver(false);

--- a/src/app/api/customFetch.ts
+++ b/src/app/api/customFetch.ts
@@ -68,6 +68,11 @@ const customFetch = async (url: string, options: RequestInit = {}) => {
       // 재발급 받은 토큰으로 동일 요청 재시도
       headers.Authorization = `Bearer ${accessToken}`;
       return fetch(url, { ...options, headers });
+    } else if (response.status === 403) {
+      // Throw an error with the status code
+      const error = new Error("Forbidden");
+      (error as any).status = 403;
+      throw error;
     } else if (response.status === 404) {
       window.location.href = "/community";
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves #90 
- resolves #91 

## 📝작업 내용
- 댓글에 한글이 있으면 기능이 제대로 동작하지 않는 문제를 해결하였습니다.
```diff
  onKeyDown={(e: any) => {
+  if (e.isComposing || e.keyCode === 229) return;
    if (e.key === "Enter") {
      onSubmit();
    }
  }}
```
문제의 원인
  - 이벤트 중복 처리: IME를 통해 한글을 입력할 때, 키다운(keydown) 이벤트가 예상치 못한 방식으로 발생합니다. 특히 Enter 키를 눌러 문자를 확정하거나 줄바꿈을 할 때, 키 이벤트가 두 번 트리거될 수 있습니다.
  - e.isComposing 및 e.keyCode === 229: IME 조합 중에는 e.isComposing 속성이 true로 설정되고, 키코드가 일반적인 값과 다르게 229로 설정됩니다. 이는 브라우저가 현재 문자를 조합 중임을 나타냅니다.
---

- 이력서 화면에서 API 요청 실패 시 처리가 애매하던 문제를 해결하였습니다.
  - 내 이력서: 본인 이력서가 아닌 경우에 /community로 돌아감
  - 커뮤니티 이력서: PRIVATE 이력서의 경우에 /community로 돌아감

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
